### PR TITLE
Making empty_symbol argument optional.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ struct Args {
     workspace_amount: u8,
 
     /// Symbol for a workspace that does not contain any windows.
-    #[arg(long, required = true, value_name = "SYMBOL")]
-    empty_symbol: char,
+    #[arg(long, required = false, value_name = "SYMBOL")]
+    empty_symbol: Option<char>,
 
     /// Symbol for a workspace that contains one or more windows.
     #[arg(long, required = true, value_name = "SYMBOL")]

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -5,7 +5,7 @@ pub fn get_workspace_symbols(
     workspace_amount: u8,
     active_workspace_symbol: char,
     full_workspace_symbol: char,
-    empty_workspace_symbol: char,
+    empty_workspace_symbol: Option<char>,
     active_workspace: &Workspace,
 ) -> Vec<char> {
     let mut symbols = Vec::new();
@@ -17,8 +17,8 @@ pub fn get_workspace_symbols(
             } else {
                 symbols.push(full_workspace_symbol);
             }
-        } else {
-            symbols.push(empty_workspace_symbol);
+        } else if let Some(empty_symbol) = empty_workspace_symbol {
+            symbols.push(empty_symbol);
         }
     }
 


### PR DESCRIPTION
Making empty_symbol argument optional, to be able to not display empty workspaces buttons on eww.