### PR TITLE
fix: workspaces buttons not switching to their according workspaces

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ struct Args {
     workspace_amount: u8,
 
     /// Symbol for a workspace that does not contain any windows.
-    #[arg(long, required = true, value_name = "SYMBOL")]
-    empty_symbol: char,
+    #[arg(long, required = false, value_name = "SYMBOL")]
+    empty_symbol: Option<char>,
 
     /// Symbol for a workspace that contains one or more windows.
     #[arg(long, required = true, value_name = "SYMBOL")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,13 +131,13 @@ fn main() {
     let workspaces = get_workspaces().expect("got no workspaces");
     let active_workspace = get_active_workspace().expect("got no active workspace");
     let symbols = symbols::get_workspace_symbols(
-        &workspaces,
-        args.workspace_amount,
-        args.active_symbol,
-        args.full_symbol,
-        args.empty_symbol,
-        &active_workspace,
-    );
+    &workspaces,
+    args.workspace_amount,
+    args.active_symbol,
+    args.full_symbol,
+    args.empty_symbol,
+    &active_workspace,
+);
 
     print_symbols(&symbols, &args);
 }
@@ -148,7 +148,7 @@ fn main() {
 ///
 /// - `workspace_symbols` - the current symbols for all workspaces.
 /// - `eww_widgets` - wheter to print eww widgets or normal symbols.
-fn print_symbols(workspace_symbols: &Vec<char>, args: &Args) {
+fn print_symbols(workspace_symbols: &Vec<(char, u8)>, args: &Args) {
     if args.eww_widgets {
         println!(
             "{}",
@@ -168,13 +168,13 @@ fn print_symbols(workspace_symbols: &Vec<char>, args: &Args) {
     } else {
         workspace_symbols
             .iter()
-            .for_each(|symbol| print!("{} ", symbol));
+            .for_each(|(symbol, _)| print!("{} ", symbol));
         println!();
     }
 }
 
 fn get_eww_widget(
-    workspace_symbols: &Vec<char>,
+    workspace_symbols: &Vec<(char, u8)>,
     eww_class_box: &Option<String>,
     eww_valign: &Option<String>,
     eww_halign: &Option<String>,
@@ -214,24 +214,23 @@ fn get_eww_widget(
     eww_widget = push_string_property(eww_widget.clone(), "orientation", eww_orientation, None);
 
     // Buttons
-    for (mut idx, symbol) in workspace_symbols.iter().enumerate() {
-        idx += 1;
-
+    for (symbol, nr) in workspace_symbols {
+        let nr_usize = *nr as usize;
         eww_widget.push_str("(button ");
 
-        eww_widget = push_string_property(eww_widget.clone(), "class", eww_class_button, Some(idx));
-        eww_widget = push_string_property(eww_widget.clone(), "onclick", eww_onclick, Some(idx));
+        eww_widget = push_string_property(eww_widget.clone(), "class", eww_class_button, Some(nr_usize));
+        eww_widget = push_string_property(eww_widget.clone(), "onclick", eww_onclick, Some(nr_usize));
         eww_widget = push_string_property(
             eww_widget.clone(),
             "onmiddleclick",
             eww_onmiddleclick,
-            Some(idx),
+            Some(nr_usize),
         );
         eww_widget = push_string_property(
             eww_widget.clone(),
             "onrightclick",
             eww_onrightclick,
-            Some(idx),
+            Some(nr_usize),
         );
 
         eww_widget.push_str(&format!("'{}')", symbol));

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -5,7 +5,7 @@ pub fn get_workspace_symbols(
     workspace_amount: u8,
     active_workspace_symbol: char,
     full_workspace_symbol: char,
-    empty_workspace_symbol: char,
+    empty_workspace_symbol: Option<char>,
     active_workspace: &Workspace,
 ) -> Vec<char> {
     let mut symbols = Vec::new();
@@ -17,8 +17,8 @@ pub fn get_workspace_symbols(
             } else {
                 symbols.push(full_workspace_symbol);
             }
-        } else {
-            symbols.push(empty_workspace_symbol);
+        } else if let Some(empty_symbol) = empty_workspace_symbol {
+            symbols.push(empty_symbol);
         }
     }
 

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -7,18 +7,20 @@ pub fn get_workspace_symbols(
     full_workspace_symbol: char,
     empty_workspace_symbol: Option<char>,
     active_workspace: &Workspace,
-) -> Vec<char> {
+) -> Vec<(char, u8)> {
     let mut symbols = Vec::new();
 
     for idx in 1..=workspace_amount {
         if let Some(workspace) = get_workspace_by_id(idx, &workspaces) {
             if workspace.id == active_workspace.id {
-                symbols.push(active_workspace_symbol);
+                symbols.push((active_workspace_symbol, idx));
             } else {
-                symbols.push(full_workspace_symbol);
+                symbols.push((full_workspace_symbol, idx));
             }
-        } else if let Some(empty_symbol) = empty_workspace_symbol {
-            symbols.push(empty_symbol);
+        } else {
+            if let Some(symbol) = empty_workspace_symbol {
+                symbols.push((symbol, idx));
+            }
         }
     }
 

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -17,8 +17,7 @@ pub fn get_workspace_symbols(
             } else {
                 symbols.push((full_workspace_symbol, idx));
             }
-        } else {
-            if let Some(symbol) = empty_workspace_symbol {
+        } else if let Some(symbol) = empty_workspace_symbol {
                 symbols.push((symbol, idx));
             }
         }


### PR DESCRIPTION
The workspaces buttons on eww were not switching to their according workspaces anymore when omitting the now optional --empty-symbol argument, since I didn't think of updating the code on that aspect, previously.

I'm not sure if this code is clean or elegant, since I don't code much at all, and I didn't know rust at all either, I used AI on that one.

Everything seems to be working fine now.